### PR TITLE
Inclusão de instalação do MongoDB no bootstrap do vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -47,7 +47,12 @@ Vagrant.configure("2") do |config|
           s.args = [config.vm.box]
         end
       end
-
+      if "#{name}" != "monitoring" then
+        srv.vm.provision "shell" do |s| 
+          s.path = "provision/install_mongo.sh"
+          s.args = [config.vm.box]
+        end
+      end
   
     end
 

--- a/provision/install_mongo.sh
+++ b/provision/install_mongo.sh
@@ -1,0 +1,13 @@
+echo "=================INSTALLING MONGODB=================="
+
+sudo cat <<-EOF > /etc/yum.repos.d/mongodb-org-4.4.repo
+[mongodb-org-4.4]
+name=MongoDB Repository
+baseurl=https://repo.mongodb.org/yum/redhat/\$releasever/mongodb-org/4.4/x86_64/
+gpgcheck=1
+enabled=1
+gpgkey=https://www.mongodb.org/static/pgp/server-4.4.asc
+EOF
+
+sudo yum update 
+sudo yum install -y mongodb-org


### PR DESCRIPTION
Essa alteração vai garantir que o mongoDB estará instalado no ambiente com um script de instalação do Vagrant. Que demora mesmo um pouco para instalar e isso ajuda a acelerar o processo.